### PR TITLE
fix: make links on about page clickable

### DIFF
--- a/src/css/about.scss
+++ b/src/css/about.scss
@@ -23,6 +23,7 @@
   background-attachment: fixed;
   background-position: center;
   opacity: 0.1;
+  pointer-events: none;
 }
 
 .para {


### PR DESCRIPTION
The links on <https://mirrorz.org/about> is not clickable; seems that the `::before` element is blocking it.