### PR TITLE
Add UESTC LUG

### DIFF
--- a/src/config/mirrors.js
+++ b/src/config/mirrors.js
@@ -9,4 +9,5 @@ module.exports = [
   "https://mirrors.hit.edu.cn/static/mirrorz.json",
   "https://mirrors.dgut.edu.cn/static/mirrorz.json",
   "https://mirrors.sustech.edu.cn/mirrorz/mirrorz.json",
+  "https://iptv.uestc.edu.cn/mirrors/mirrorz.json"
 ]


### PR DESCRIPTION
Since we have not officially opened mirrors outside UESTC, we can only provide URL through IPTV reverse proxy. 