### PR TITLE
Parser: neusoft.js stop using reverse proxy

### DIFF
--- a/src/parser/neusoft.js
+++ b/src/parser/neusoft.js
@@ -33,7 +33,7 @@ const human = function(size) {
 export default async function () {
   const name_func = await cname();
   const site = await (await fetch("/static/json/site/neusoft.json")).json();
-  const repos = await (await fetch("https://r.zenithal.workers.dev/http://mirrors.neusoft.edu.cn/repos.html")).json();
+  const repos = await (await fetch("https://mirrors.neusoft.edu.cn/repos.html")).json();
 
   const mirrors = [];
   for (k in repos) {


### PR DESCRIPTION
As upstream has opened CORS for their data.
This relates to #31