### PR TITLE
Parser: ES6 to CommonJS; relative path to absolute path

### DIFF
--- a/src/parser/bfsu.js
+++ b/src/parser/bfsu.js
@@ -1,11 +1,11 @@
-import { cname } from "./utils";
-import tunasync from "./tunasync";
-import options from "./options";
-import isoinfo from "./isoinfo";
+const cname = require("./utils").cname;
+const tunasync = require("./tunasync");
+const options = require("./options");
+const isoinfo = require("./isoinfo");
 
-export default async function () {
+module.exports = async function () {
   const name_func = await cname();
-  const site = await (await fetch("/static/json/site/bfsu.json")).json();
+  const site = await (await fetch("https://mirrorz.org/static/json/site/bfsu.json")).json();
   let mirrors = await tunasync("https://mirrors.bfsu.edu.cn/static/tunasync.json");
   mirrors = await options("https://mirrors.bfsu.edu.cn/static/js/options.json", mirrors);
   info = await isoinfo("https://mirrors.bfsu.edu.cn/static/status/isoinfo.json");

--- a/src/parser/cqu.js
+++ b/src/parser/cqu.js
@@ -1,10 +1,10 @@
-import { cname } from "./utils";
-import tunasync from "./tunasync";
-import isoinfo from "./isoinfo";
+const cname = require("./utils").cname;
+const tunasync = require("./tunasync");
+const isoinfo = require("./isoinfo");
 
-export default async function () {
+module.exports = async function () {
   const name_func = await cname();
-  const site = await (await fetch("/static/json/site/cqu.json")).json();
+  const site = await (await fetch("https://mirrorz.org/static/json/site/cqu.json")).json();
   const mirrors = await tunasync("https://mirrors.cqu.edu.cn/static/tunasync.json");
   const info = await isoinfo("https://mirrors.cqu.edu.cn/static/isoinfo.json");
 

--- a/src/parser/disk.js
+++ b/src/parser/disk.js
@@ -8,7 +8,7 @@ const human = function(size) {
   return size.toFixed(2) + scale[i];
 }
 
-export default async function (diskUrl) {
+module.exports = async function (diskUrl) {
   const disk = await (await fetch(diskUrl)).json();
   return human(disk.used_kb) + "/" + human(disk.total_kb);
 };

--- a/src/parser/hit.js
+++ b/src/parser/hit.js
@@ -1,11 +1,11 @@
-import { cname } from "./utils";
-import tunasync from "./tunasync";
-import options from "./options";
-import isoinfo from "./isoinfo";
+const cname = require("./utils").cname;
+const tunasync = require("./tunasync");
+const options = require("./options");
+const isoinfo = require("./isoinfo");
 
-export default async function () {
+module.exports = async function () {
   const name_func = await cname();
-  const site = await (await fetch("/static/json/site/hit.json")).json();
+  const site = await (await fetch("https://mirrorz.org/static/json/site/hit.json")).json();
   let mirrors = await tunasync("https://mirrors.hit.edu.cn/jobs");
 
   return {

--- a/src/parser/hust.js
+++ b/src/parser/hust.js
@@ -1,4 +1,4 @@
-import { cname } from "./utils";
+const cname = require("./utils").cname;
 
 const MAP = {
   Synchronized: "S",
@@ -17,9 +17,9 @@ const statusConverter = function(time, status) {
     return c + "O" + t;
 };
 
-export default async function () {
+module.exports = async function () {
   const name_func = await cname();
-  const site = await (await fetch("/static/json/site/hust.json")).json();
+  const site = await (await fetch("https://mirrorz.org/static/json/site/hust.json")).json();
   const html = await (await fetch("https://r.zenithal.workers.dev/http://mirror.hust.edu.cn/")).text();
 
   const parser = new DOMParser();

--- a/src/parser/isoinfo.js
+++ b/src/parser/isoinfo.js
@@ -1,6 +1,6 @@
-import { cname } from "./utils";
+const cname = require("./utils").cname;
 
-export default async function (isoinfoUrl) {
+module.exports = async function (isoinfoUrl) {
   const name_func = await cname();
   const isoinfo = await (await fetch(isoinfoUrl)).json();
 

--- a/src/parser/lzu.js
+++ b/src/parser/lzu.js
@@ -1,4 +1,4 @@
-import { cname } from "./utils";
+const cname = require("./utils").cname;
 
 const MAP = {
   success: "S",
@@ -21,9 +21,9 @@ const statusConverter = function(time, status) {
     return c + "O" + t;
 };
 
-export default async function () {
+module.exports = async function () {
   const name_func = await cname();
-  const site = await (await fetch("/static/json/site/lzu.json")).json();
+  const site = await (await fetch("https://mirrorz.org/static/json/site/lzu.json")).json();
   const html = await (await fetch("https://r.zenithal.workers.dev/http://mirror.lzu.edu.cn/")).text();
 
   const parser = new DOMParser();

--- a/src/parser/nano.js
+++ b/src/parser/nano.js
@@ -1,11 +1,11 @@
-import { cname } from "./utils";
-import tunasync from "./tunasync";
-import options from "./options";
-import disk from "./disk";
+const cname = require("./utils").cname;
+const tunasync = require("./tunasync");
+const options = require("./options");
+const disk = require("./disk");
 
-export default async function () {
+module.exports = async function () {
   const name_func = await cname();
-  const site = await (await fetch("/static/json/site/nano.json")).json();
+  const site = await (await fetch("https://mirrorz.org/static/json/site/nano.json")).json();
   site["disk"] = await disk("https://mirrors.tuna.tsinghua.edu.cn/static/status/nano/disk.json")
 
   let mirrors = await tunasync("https://mirrors.tuna.tsinghua.edu.cn/static/tunasync.json.nano");

--- a/src/parser/neo.js
+++ b/src/parser/neo.js
@@ -1,11 +1,11 @@
-import { cname } from "./utils";
-import tunasync from "./tunasync";
-import options from "./options";
-import disk from "./disk";
+const cname = require("./utils").cname;
+const tunasync = require("./tunasync");
+const options = require("./options");
+const disk = require("./disk");
 
-export default async function () {
+module.exports = async function () {
   const name_func = await cname();
-  const site = await (await fetch("/static/json/site/neo.json")).json();
+  const site = await (await fetch("https://mirrorz.org/static/json/site/neo.json")).json();
   site["disk"] = await disk("https://mirrors.tuna.tsinghua.edu.cn/static/status/neo/disk.json")
 
   let mirrors = await tunasync("https://mirrors.tuna.tsinghua.edu.cn/static/tunasync.json.neo");

--- a/src/parser/neusoft.js
+++ b/src/parser/neusoft.js
@@ -1,4 +1,4 @@
-import { cname } from "./utils";
+const cname = require("./utils").cname;
 
 const statusConverter = function(time, status) {
   let c = undefined;
@@ -30,9 +30,9 @@ const human = function(size) {
   return size.toFixed(2) + scale[i];
 }
 
-export default async function () {
+module.exports = async function () {
   const name_func = await cname();
-  const site = await (await fetch("/static/json/site/neusoft.json")).json();
+  const site = await (await fetch("https://mirrorz.org/static/json/site/neusoft.json")).json();
   const repos = await (await fetch("https://mirrors.neusoft.edu.cn/repos.html")).json();
 
   const mirrors = [];

--- a/src/parser/nju-old.js
+++ b/src/parser/nju-old.js
@@ -1,6 +1,6 @@
-import { cname } from "./utils";
+const cname = require("./utils").cname;
 
-export default async function () {
+module.exports = async function () {
   const name_func = await cname();
   const site = await (await fetch("https://mirrors.nju.edu.cn/.mirrorz/site.json")).json();
   const html = await (await fetch("https://r.zenithal.workers.dev/https://mirrors.nju.edu.cn/")).text();

--- a/src/parser/nju.js
+++ b/src/parser/nju.js
@@ -1,8 +1,8 @@
-import { cname } from "./utils";
-import tunasync from "./tunasync";
-import options from "./options";
+const cname = require("./utils").cname;
+const tunasync = require("./tunasync");
+const options = require("./options");
 
-export default async function () {
+module.exports = async function () {
   const name_func = await cname();
   const site = await (await fetch("https://mirrors.nju.edu.cn/.mirrorz/site.json")).json();
   const mirrors = await tunasync("https://mirrors.nju.edu.cn/.mirrorz/tunasync.json");

--- a/src/parser/options.js
+++ b/src/parser/options.js
@@ -1,6 +1,6 @@
-import { cname } from "./utils";
+const cname = require("./utils").cname;
 
-export default async function (optionsUrl, mirrors) {
+module.exports = async function (optionsUrl, mirrors) {
   const name_func = await cname();
   const options = await (await fetch(optionsUrl)).json();
 

--- a/src/parser/tuna.js
+++ b/src/parser/tuna.js
@@ -1,11 +1,11 @@
-import { cname } from "./utils";
-import tunasync from "./tunasync";
-import options from "./options";
-import isoinfo from "./isoinfo";
+const cname = require("./utils").cname;
+const tunasync = require("./tunasync");
+const options = require("./options");
+const isoinfo = require("./isoinfo");
 
-export default async function () {
+module.exports = async function () {
   const name_func = await cname();
-  const site = await (await fetch("/static/json/site/tuna.json")).json();
+  const site = await (await fetch("https://mirrorz.org/static/json/site/tuna.json")).json();
   let mirrors = await tunasync("https://mirrors.tuna.tsinghua.edu.cn/static/tunasync.json");
   mirrors = await options("https://mirrors.tuna.tsinghua.edu.cn/static/js/options.json", mirrors);
   info = await isoinfo("https://mirrors.tuna.tsinghua.edu.cn/static/status/isoinfo.json");

--- a/src/parser/tunasync.js
+++ b/src/parser/tunasync.js
@@ -1,4 +1,4 @@
-import { cname } from "./utils";
+const cname = require("./utils").cname;
 
 const MAP = {
   success: "S",
@@ -35,7 +35,7 @@ const statusConverter = function(item) {
   return s;
 };
 
-export default async function (tunasyncUrl) {
+module.exports = async function (tunasyncUrl) {
   const name_func = await cname();
   const tunasync = await (await fetch(tunasyncUrl)).json();
 

--- a/src/parser/utils.js
+++ b/src/parser/utils.js
@@ -1,4 +1,4 @@
-export const cname = async function() {
-  const cname = await (await fetch("/static/json/cname.json")).json();
+exports.cname = async function() {
+  const cname = await (await fetch("https://mirrorz.org/static/json/cname.json")).json();
   return (name) => { return (name in cname) ? cname[name] : name; };
 };

--- a/src/parser/xjtu.js
+++ b/src/parser/xjtu.js
@@ -1,9 +1,9 @@
-import { cname } from "./utils";
-import tunasync from "./tunasync";
+const cname = require("./utils").cname;
+const tunasync = require("./tunasync");
 
-export default async function () {
+module.exports = async function () {
   const name_func = await cname();
-  const site = await (await fetch("/static/json/site/xjtu.json")).json();
+  const site = await (await fetch("https://mirrorz.org/static/json/site/xjtu.json")).json();
   const mirrors = await tunasync("https://r.zenithal.workers.dev/https://mirrors.xjtu.edu.cn/api/status.json");
 
   return {


### PR DESCRIPTION
Parser should be able to be used by other programs like `node`, hence a more common set of syntax was used.

Also relative path was changed to absolute path. This may harm localhost debugging.