### PR TITLE
Add visual diff

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
           path: drop/dist.tar.gz
           retention-days: 3
   screenshots:
-    name: Take screenshots
+    name: Visual diff
     runs-on: ubuntu-latest
     needs:
       - build
@@ -60,14 +60,29 @@ jobs:
       - name: Unzip dist package
         run: |
           tar xzf dist.tar.gz
+      - name: Update snapshot baseline
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: |
+          yarn test --update-snapshots
+      - name: Upload screenshot baseline as artifacts
+        if: ${{ github.ref == 'refs/heads/master' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: screenshot-baseline
+          path: |
+            tests/*-snapshot
       - name: Take screenshots
+        if: ${{ github.ref != 'refs/heads/master' }}
         run: |
           yarn test
-      - name: Upload screenshots as artifacts
+      - name: Upload screenshot differences as artifacts
+        if: ${{ github.ref != 'refs/heads/master' }}
         uses: actions/upload-artifact@v2
         with:
           name: screenshots
-          path: drop/screenshots
+          path: |
+            tests/*-snapshot
+            test-results
           retention-days: 3
   deploy:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 head.pug
 .DS_Store
 /drop
+/tests/*.spec.[jt]s-snapshots
+/test-results

--- a/tests/screenshots.spec.ts
+++ b/tests/screenshots.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import { server } from "./test-server";
 
 const baseUrl = 'http://localhost:8000';
@@ -15,7 +15,7 @@ test.beforeAll(async () => {
 Object.entries(testPages).map(([name, url]) => test(name, async ({ browserName, page }) => {
     await page.goto(baseUrl + url);
     await page.waitForTimeout(1000);
-    await page.screenshot({ path: `drop/screenshots/${browserName}/${name}.png` });
+    expect(await page.screenshot({ fullPage: true })).toMatchSnapshot(name + '.png');
 }));
 
 test.afterAll(async () => {


### PR DESCRIPTION
This PR will add visual diff in CI builds, but the baseline snapshots are not downloaded for later builds, thus visual diff doesn't mean any thing yet.
The workflow should download snapshot baseline from the previous run on master branch (or latest run on master branch if workflow is running on PR), and it will be introduced in separate PR since we need to have baseline first.